### PR TITLE
fix: add blank setNativeProps function on mocked View

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const OriginalTouchableOpacity = ReactNative.TouchableOpacity;
 function getMockContainer(OriginalComponent) {
   return class extends React.Component {
     static displayName = 'View';
+    setNativeProps() {}  
     render() {
       return <OriginalComponent {...this.props}><HighlightComponent />{this.props.children}</OriginalComponent>;
     }


### PR DESCRIPTION
Prevents error from https://github.com/react-navigation/react-navigation/blob/main/packages/stack/src/views/Stack/Card.tsx#L238

Passing an empty function since this I only use `react-native-highlight-updates` for debugging anyways.

![Simulator Screen Shot - iPhone 11 - 2020-10-12 at 21 44 09](https://user-images.githubusercontent.com/2933593/95816860-f51f4780-0cd4-11eb-8d03-55097fd37edf.png)
